### PR TITLE
Additional checking to register component only once

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,6 +2,7 @@
   "predef": [
     "document",
     "window",
+    "Ember",
     "-Promise"
   ],
   "browser": true,

--- a/addon/action-format.js
+++ b/addon/action-format.js
@@ -1,8 +1,8 @@
-import Em from 'ember';
+import Ember from 'ember';
 import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
-var computed = Em.computed;
+var computed = Ember.computed;
 
-export default Em.Component.extend(WithConfigMixin, {
+export default Ember.Component.extend(WithConfigMixin, {
   tagName: 'a',
   classNameBindings: ['styleClasses', 'activeClasses'],
   styleClasses: (function() {

--- a/addon/action-group.js
+++ b/addon/action-group.js
@@ -1,6 +1,6 @@
-import Em from 'ember';
+import Ember from 'ember';
 import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
-var computed = Em.computed;
+var computed = Ember.computed;
 
 /**
  * ActionGroup component
@@ -8,7 +8,7 @@ var computed = Em.computed;
  * @class ActionGroup
  */
 
-export default Em.Component.extend(WithConfigMixin, {
+export default Ember.Component.extend(WithConfigMixin, {
   classNameBindings: ['styleClasses'],
   styleClasses: (function() {
     var _ref;

--- a/addon/action-link-modal.js
+++ b/addon/action-link-modal.js
@@ -1,4 +1,9 @@
-import Em from 'ember';
+import Ember from 'ember';
+
+const {
+  on,
+  Component
+} = Ember;
 
 /**
  * ActionGroup component
@@ -6,8 +11,8 @@ import Em from 'ember';
  * @class ActionGroup
  */
 
-export default Em.Component.extend({
-  registerInParent: (function() {
+export default Component.extend({
+  registerInParent: on('didInsertElement', function() {
     this.set('parentView.model', this);
-  }).on('didInsertElement')
+  })
 });

--- a/addon/action-link.js
+++ b/addon/action-link.js
@@ -2,6 +2,7 @@ import Em from 'ember';
 import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
 import Modal from 'ember-idx-modal/modal';
 var computed = Em.computed;
+var COMPONENT_NAME = 'view:em-wysiwyg-action-link-modal';
 
 export default Em.Component.extend(WithConfigMixin, {
   tagName: 'a',
@@ -9,18 +10,20 @@ export default Em.Component.extend(WithConfigMixin, {
   linkHref: '',
   initModal: (function() {
     var container = this.get('container');
-    container.register('view:em-wysiwyg-action-link-modal', Modal.extend({
-      layoutName: 'components/em-wysiwyg-action-link-modal',
-      configName: 'bs',
-      _parentView: this,
-      linkHref: computed.alias('parentView.linkHref'),
-      actions: {
-        addLink: function() {
-          this.get('parentView').send('addLink');
+    if(!container.lookupFactory(COMPONENT_NAME)) {
+      container._registry.register(COMPONENT_NAME, Modal.extend({
+        layoutName: 'components/em-wysiwyg-action-link-modal',
+        configName: 'bs',
+        _parentView: this,
+        linkHref: computed.alias('parentView.linkHref'),
+        actions: {
+          addLink: function() {
+            this.get('parentView').send('addLink');
+          }
         }
-      }
-    }));
-    this.set('modal', container.lookup('view:em-wysiwyg-action-link-modal'));
+      }));
+    }
+    this.set('modal', container.lookup(COMPONENT_NAME));
     return this.get('modal').append();
   }).on('init'),
   styleClasses: (function() {

--- a/addon/action-link.js
+++ b/addon/action-link.js
@@ -1,10 +1,10 @@
-import Em from 'ember';
+import Ember from 'ember';
 import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
 import Modal from 'ember-idx-modal/modal';
-var computed = Em.computed;
+var computed = Ember.computed;
 var COMPONENT_NAME = 'view:em-wysiwyg-action-link-modal';
 
-export default Em.Component.extend(WithConfigMixin, {
+export default Ember.Component.extend(WithConfigMixin, {
   tagName: 'a',
   classNameBindings: ['styleClasses', 'activeClasses'],
   linkHref: '',
@@ -64,7 +64,7 @@ export default Em.Component.extend(WithConfigMixin, {
           container = container.parentNode;
         }
         if (container.nodeName === "A") {
-          _this.set('linkHref', Em.$(container).attr('href'));
+          _this.set('linkHref', Ember.$(container).attr('href'));
           return _this.set('active', true);
         } else {
           _this.set('linkHref', '');

--- a/addon/action-text-html-toggler.js
+++ b/addon/action-text-html-toggler.js
@@ -1,8 +1,8 @@
-import Em from 'ember';
+import Ember from 'ember';
 import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
-var computed = Em.computed;
+var computed = Ember.computed;
 
-export default Em.Component.extend(WithConfigMixin, {
+export default Ember.Component.extend(WithConfigMixin, {
   tagName: 'a',
   layoutName: 'components/em-wysiwyg-action',
   classNameBindings: ['styleClasses', 'activeClasses'],

--- a/addon/action.js
+++ b/addon/action.js
@@ -1,8 +1,8 @@
-import Em from 'ember';
+import Ember from 'ember';
 import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
-var computed = Em.computed;
+var computed = Ember.computed;
 
-export default Em.Component.extend(WithConfigMixin, {
+export default Ember.Component.extend(WithConfigMixin, {
   tagName: 'a',
   classNameBindings: ['styleClasses', 'activeClasses'],
   styleClasses: (function() {

--- a/addon/editor-textarea.js
+++ b/addon/editor-textarea.js
@@ -1,8 +1,8 @@
-import Em from 'ember';
-var computed = Em.computed;
+import Ember from 'ember';
+var computed = Ember.computed;
 import StyleBindingsMixin from 'ember-idx-utils/mixin/style-bindings';
 
-export default Em.TextArea.extend(StyleBindingsMixin, {
+export default Ember.TextArea.extend(StyleBindingsMixin, {
     styleBindings: ['display', 'width', 'border'],
     width: '100%',
     border: 'none;',

--- a/addon/editor.js
+++ b/addon/editor.js
@@ -61,10 +61,10 @@ export default Em.Component.extend(StyleBindingsMixin, {
     }
     return this.saveSelection();
   },
-  register: (function() {
+  register: Ember.on('didInsertElement', function() {
     return this.get('wysiwyg').setEditor(this);
-  }).on('didInsertElement'),
-  unregister: (function() {
+  }),
+  unregister: Ember.on('willDestroyElement', function() {
     return this.get('wysiwyg').setEditor(void 0);
-  }).on('willDestroyElement')
+  })
 });

--- a/addon/editor.js
+++ b/addon/editor.js
@@ -37,6 +37,12 @@ export default Em.Component.extend(StyleBindingsMixin, {
   restoreSelection: function() {
     var e, selection;
     selection = window.getSelection();
+    var selectionStr = selection.toString();
+    var contentStr = this.$().text();
+    if(selectionStr === contentStr) {
+      return selection;
+    }
+
     if (this.get('selectionRange')) {
       try {
         selection.removeAllRanges();

--- a/addon/editor.js
+++ b/addon/editor.js
@@ -1,14 +1,14 @@
-import Em from 'ember';
+import Ember from 'ember';
 import StyleBindingsMixin from 'ember-idx-utils/mixin/style-bindings';
 
-export default Em.Component.extend(StyleBindingsMixin, {
+export default Ember.Component.extend(StyleBindingsMixin, {
   styleBindings: ['marginTop:margin-top', 'background', 'display'],
   attributeBindings: ['contenteditable'],
   contenteditable: 'true',
   marginTop: 10,
   background: 'white',
   display: 'block',
-  wysiwyg: Em.computed.alias('parentView'),
+  wysiwyg: Ember.computed.alias('parentView'),
   updateToolbar: function(e) {
     return this.get('wysiwyg').trigger('update_actions');
   },

--- a/addon/toolbar.js
+++ b/addon/toolbar.js
@@ -1,7 +1,10 @@
 import Em from 'ember';
 import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
 
-var computed = Em.computed;
+const {
+  on,
+  computed
+} = Em;
 
 /**
  * Toolbar component
@@ -10,23 +13,23 @@ var computed = Em.computed;
  */
 export default Em.Component.extend(WithConfigMixin, {
   classNameBindings: ['styleClasses'],
-  styleClasses: (function() {
+  styleClasses: computed(function() {
     var _ref;
     return (_ref = this.get('config.wysiwyg.toolbarClasses')) != null ? _ref.join(" ") : void 0;
-  }).property(),
+  }),
   groups: void 0,
-  initGroups: (function() {
+  initGroups: on('init', function() {
     return this.set('groups', Em.ArrayProxy.create({
       content: []
     }));
-  }).on('init'),
+  }),
   wysiwyg: computed.alias('parentView'),
-  register: (function() {
+  register: on('didInsertElement', function() {
     return this.get('wysiwyg').addToolbar(this);
-  }).on('didInsertElement'),
-  unregister: (function() {
+  }),
+  unregister: on('willDestroyElement', function() {
     return this.get('wysiwyg').removeToolbar(this);
-  }).on('willDestroyElement'),
+  }),
   addGroup: function(g) {
     return this.get('groups').addObject(g);
   },

--- a/addon/toolbar.js
+++ b/addon/toolbar.js
@@ -1,17 +1,17 @@
-import Em from 'ember';
+import Ember from 'ember';
 import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
 
 const {
   on,
   computed
-} = Em;
+} = Ember;
 
 /**
  * Toolbar component
  *
  * @class Toolbar
  */
-export default Em.Component.extend(WithConfigMixin, {
+export default Ember.Component.extend(WithConfigMixin, {
   classNameBindings: ['styleClasses'],
   styleClasses: computed(function() {
     var _ref;
@@ -19,7 +19,7 @@ export default Em.Component.extend(WithConfigMixin, {
   }),
   groups: void 0,
   initGroups: on('init', function() {
-    return this.set('groups', Em.ArrayProxy.create({
+    return this.set('groups', Ember.ArrayProxy.create({
       content: []
     }));
   }),

--- a/addon/wysiwyg.js
+++ b/addon/wysiwyg.js
@@ -9,10 +9,10 @@ import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
 
 export default Em.Component.extend(WithConfigMixin, {
   classNameBindings: ['styleClasses'],
-  styleClasses: (function() {
+  styleClasses: Ember.computed(function() {
     var _ref;
     return (_ref = this.get('config.wysiwyg.classes')) != null ? _ref.join(" ") : void 0;
-  }).property(),
+  }),
 
   /**
    * A list of {{#crossLink "Toolbar"}}toolbar{{/crossLink}} instances.
@@ -23,19 +23,19 @@ export default Em.Component.extend(WithConfigMixin, {
    * The editor view
    */
   editor: void 0,
-  initToolbars: (function() {
+  initToolbars: Ember.on('init', function() {
     return this.set('toolbars', Em.ArrayProxy.create({
       content: []
     }));
-  }).on('init'),
+  }),
 
-  initEditorContent: (function() {
+  initEditorContent: Ember.observer('editor', function() {
     if (this.get('editor')) {
       return Em.run.once(this, (function() {
         return this.get('editor').$().html(this.get('as_html'));
       }));
     }
-  }).observes('editor'),
+  }),
 
   /**
    * Add the given `Toolbar` instance.
@@ -60,7 +60,7 @@ export default Em.Component.extend(WithConfigMixin, {
     }
     return this.set('editor', editor);
   },
-  asHtmlUpdater: (function() {
+  asHtmlUpdater: Ember.on('update_actions', function() {
     return this.set('as_html', this.get('editor').$().html().replace(/(<br>|\s|<div><br><\/div>|&nbsp;)*$/, ''));
-  }).on('update_actions')
+  })
 });

--- a/addon/wysiwyg.js
+++ b/addon/wysiwyg.js
@@ -55,6 +55,9 @@ export default Em.Component.extend(WithConfigMixin, {
    * Set the editor instance
    */
   setEditor: function(editor) {
+    if (editor && editor.element) {
+      editor.element.addEventListener('paste', () => Em.run.scheduleOnce('afterRender', this, this.asHtmlUpdater));
+    }
     return this.set('editor', editor);
   },
   asHtmlUpdater: (function() {

--- a/addon/wysiwyg.js
+++ b/addon/wysiwyg.js
@@ -1,4 +1,4 @@
-import Em from 'ember';
+import Ember from 'ember';
 import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
 
 /**
@@ -7,7 +7,7 @@ import WithConfigMixin from 'ember-idx-utils/mixin/with-config';
  * @class Wysiwyg
  */
 
-export default Em.Component.extend(WithConfigMixin, {
+export default Ember.Component.extend(WithConfigMixin, {
   classNameBindings: ['styleClasses'],
   styleClasses: Ember.computed(function() {
     var _ref;
@@ -24,14 +24,14 @@ export default Em.Component.extend(WithConfigMixin, {
    */
   editor: void 0,
   initToolbars: Ember.on('init', function() {
-    return this.set('toolbars', Em.ArrayProxy.create({
+    return this.set('toolbars', Ember.ArrayProxy.create({
       content: []
     }));
   }),
 
   initEditorContent: Ember.observer('editor', function() {
     if (this.get('editor')) {
-      return Em.run.once(this, (function() {
+      return Ember.run.once(this, (function() {
         return this.get('editor').$().html(this.get('as_html'));
       }));
     }
@@ -56,10 +56,11 @@ export default Em.Component.extend(WithConfigMixin, {
    */
   setEditor: function(editor) {
     if (editor && editor.element) {
-      editor.element.addEventListener('paste', () => Em.run.scheduleOnce('afterRender', this, this.asHtmlUpdater));
+      editor.element.addEventListener('paste', () => Ember.run.scheduleOnce('afterRender', this, this.asHtmlUpdater));
     }
     return this.set('editor', editor);
   },
+
   asHtmlUpdater: Ember.on('update_actions', function() {
     return this.set('as_html', this.get('editor').$().html().replace(/(<br>|\s|<div><br><\/div>|&nbsp;)*$/, ''));
   })

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "ember-cli": "0.1.4",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.6",
-    "ember-cli-esnext": "0.1.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.1.2",
@@ -43,7 +42,9 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "ember-idx-utils": "^0.2.2",
-    "ember-idx-modal": "^0.1.3"
+    "broccoli-babel-transpiler": "^5.4.5",
+    "ember-cli-babel": "^5.1.5",
+    "ember-idx-modal": "^0.1.3",
+    "ember-idx-utils": "^0.2.2"
   }
 }

--- a/tests/dummy/app/initializers/hightlightjs.js
+++ b/tests/dummy/app/initializers/hightlightjs.js
@@ -1,12 +1,14 @@
 import Em from 'ember';
-import Config from 'ember-idx-utils/config';
+import UtilsConfig from 'ember-idx-utils/config';
 /*global hljs*/
+
+var Config;
 
 export default {
   name: 'hightlightjs',
   initialize: function() {
     //In real app we don't need this coz the initializer of modal will be merged into the app and will run automatically
-    Em.Config = Config = Config.create();
+    Em.Config = Config = UtilsConfig.create();
     var defaultConfig = Config.getConfig('bs');
 
     if (!defaultConfig) {


### PR DESCRIPTION
After Ember update there are code, which check if component was already registered. And on trying to reregister component -- it's throw an error. 

Old implementation register component on every initialization ( we've got an error on multiple wysiwyg at form )
